### PR TITLE
fix: Load current theme after enabling ef-themes

### DIFF
--- a/ef-themes.el
+++ b/ef-themes.el
@@ -69,10 +69,12 @@
    custom-known-themes))
 
 (defun ef-themes--enable-themes ()
+  (setq-local current-theme (car custom-enabled-themes))
   (mapc (lambda (theme)
           (load-theme theme :no-confirm :no-enable))
         (append ef-themes-light-themes
-                ef-themes-dark-themes)))
+                ef-themes-dark-themes))
+  (load-theme current-theme :no-confirm))
 
 (defun ef-themes--current-theme ()
   "Return first enabled Ef theme."

--- a/ef-themes.el
+++ b/ef-themes.el
@@ -69,12 +69,12 @@
    custom-known-themes))
 
 (defun ef-themes--enable-themes ()
-  (setq-local current-theme (car custom-enabled-themes))
-  (mapc (lambda (theme)
-          (load-theme theme :no-confirm :no-enable))
-        (append ef-themes-light-themes
-                ef-themes-dark-themes))
-  (load-theme current-theme :no-confirm))
+  (let ((current-theme (car custom-enabled-themes)))
+    (mapc (lambda (theme)
+            (load-theme theme :no-confirm :no-enable))
+          (append ef-themes-light-themes
+                  ef-themes-dark-themes))
+    (load-theme current-theme :no-confirm)))
 
 (defun ef-themes--current-theme ()
   "Return first enabled Ef theme."


### PR DESCRIPTION
If a custom theme is loaded then `ef-select-theme` is called and no candidate is selected (C-g), then the result theme is something like this:
![image](https://user-images.githubusercontent.com/3024945/185469081-8e76f615-7602-403a-99d5-abcc8ad0ee58.png)

I guess this is because of: 
```
(mapc #'disable-theme custom-enabled-themes)
```

This PR tries to reload the custom theme which was active when calling the function `ef-themes--enable-themes`
