### PR TITLE
Add support for perspective

### DIFF
--- a/README.org
+++ b/README.org
@@ -992,6 +992,7 @@ everything most users need.
 - outline-mode
 - outline-minor-faces
 - package (=M-x list-packages=)
+- perspective
 - pulsar
 - pulse
 - rainbow-delimiters

--- a/ef-themes.el
+++ b/ef-themes.el
@@ -1596,6 +1596,8 @@ Helper function for `ef-themes-preview-colors'."
     `(package-status-installed ((,c :foreground ,fg-alt)))
     `(package-status-new ((,c :inherit success)))
     `(package-status-unsigned ((,c :inherit error)))
+;;;; perspective
+    `(persp-selected-face ((,c :inherit mode-line-emphasis)))
 ;;;; pulsar
     `(pulsar-blue ((,c :background ,bg-blue-subtle)))
     `(pulsar-cyan ((,c :background ,bg-cyan-subtle)))


### PR DESCRIPTION
This is the default definition which can clash depending on the theme:

```elisp
(defface persp-selected-face
  '((t (:weight bold :foreground "Blue")))
  "The face used to highlight the current perspective on the modeline.")
```

It's the only face in `perspective`.