### PR TITLE
Add support for `highlight-identation` mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -1356,6 +1356,7 @@ everything most users need.
 - git-rebase
 - gnus
 - hi-lock (=M-x highlight-regexp=)
+- highlight-indentation
 - ibuffer
 - image-dired
 - imenu-list [ Part of {{{development-version}}}. ]

--- a/ef-themes.el
+++ b/ef-themes.el
@@ -1564,6 +1564,8 @@ text should not be underlined as well) yet still blend in."
                   :background "white" :foreground "#af6f00" :inverse-video t)
                  (((class color) (min-colors 88) (background dark))
                   :background "black" :foreground "#faea00" :inverse-video t)))
+;;;; highlight-indentation mode
+    `(highlight-indentation-face ((,c :background ,bg-dim)))
 ;;;; ibuffer
     `(ibuffer-locked-buffer ((,c :foreground ,warning)))
 ;;;; image-dired


### PR DESCRIPTION
Add support for highlight-indentation mode. I hope `bg-dim` is good for this, at least it looks well IMO.
I use this mode mostly for editing YAML files, where it is very useful to see the correct indent level.

![image](https://github.com/protesilaos/ef-themes/assets/3540984/60209e87-8d3a-4681-94b3-483970a0a9d5)
![image](https://github.com/protesilaos/ef-themes/assets/3540984/746f64d9-e176-4fc4-8754-f44445cebdb5)
