### PR TITLE
Fix `:background-mode` property for ef-rosa and ef-melissa-dark

### DIFF
--- a/ef-melissa-dark-theme.el
+++ b/ef-melissa-dark-theme.el
@@ -39,7 +39,7 @@
 ;;;###theme-autoload
   (deftheme ef-melissa-dark
     "Legible dark theme with warm colors (yellow, red, green, cyan)."
-    :background-mode 'light
+    :background-mode 'dark
     :kind 'color-scheme
     :family 'ef)
 

--- a/ef-rosa-theme.el
+++ b/ef-rosa-theme.el
@@ -39,7 +39,7 @@
 ;;;###theme-autoload
   (deftheme ef-rosa
     "Legible dark theme with magenta and green colors."
-    :background-mode 'light
+    :background-mode 'dark
     :kind 'color-scheme
     :family 'ef)
 


### PR DESCRIPTION
Themes ef-rosa and ef-melissa-dark had a mismatched `:background-mode` property set to `'light` -- they're actually dark themes.