### PR TITLE
Add support for transient-key-stack face

### DIFF
--- a/ef-themes.el
+++ b/ef-themes.el
@@ -2405,7 +2405,7 @@ text should not be underlined as well) yet still blend in."
     `(transient-key-noop ((,c :inherit (shadow ef-themes-key-binding))))
     `(transient-key-recurse ((,c :inherit ef-themes-key-binding)))
     `(transient-key-return ((,c :inherit ef-themes-key-binding)))
-    `(transient-key-stay ((,c :inherit ef-themes-key-binding)))
+    `(transient-key-stack ((,c :inherit ef-themes-key-binding)))
     `(transient-key-stay ((,c :inherit ef-themes-key-binding)))
     `(transient-mismatched-key ((,c :underline t)))
     `(transient-nonstandard-key ((,c :underline t)))


### PR DESCRIPTION
I believe the intention of 295982164ce0c359ac4e0be44d7f6ef472177d35 was to add support for the `transient-key-recurse` and `transient-key-stack` faces that were recently added to Transient. But rather than `transient-key-stack`, a duplicate handling of `transient-key-stay` was added.