### PR TITLE
Add optional argument to silence message in ef-themes-load-random

### DIFF
--- a/ef-themes.el
+++ b/ef-themes.el
@@ -698,13 +698,16 @@ respectively.  Else check against the return value of
     (delete (ef-themes--current-theme) themes)))
 
 ;;;###autoload
-(defun ef-themes-load-random (&optional variant)
+(defun ef-themes-load-random (&optional variant silent)
   "Load an Ef theme at random, excluding the current one.
 
 With optional VARIANT as a prefix argument, prompt to limit the
 set of themes to either dark or light variants.
 
 Run `ef-themes-post-load-hook' after loading the theme.
+
+Print the name of the new theme, unless optional argument SILENT is
+non-nil.
 
 When called from Lisp, VARIANT is either the `dark' or `light'
 symbol."
@@ -714,7 +717,8 @@ symbol."
          (pick (nth n themes))
          (loaded (if (null pick) (car themes) pick)))
     (ef-themes-load-theme loaded)
-    (message "Loaded `%s'" loaded)))
+    (unless silent
+      (message "Loaded `%s'" loaded))))
 
 ;;;; Rotate through a list of themes
 


### PR DESCRIPTION
Hi Prot,

This change adds a new optional argument to silence the message printed by `ef-themes-load-random`.

My motivation is that I use an idle timer to change the theme after I've been away from my computer for a while:

    (run-with-idle-timer (* 60 60 4) 'repeat 'ef-themes-load-random 'dark)

This works great! My only issue is that there is always a message in the echo area when I come back. I'd like to be able to silence it somehow.

Please let me know if you think this is a good idea, or if you'd like to take a different approach.

Thanks!